### PR TITLE
User and multiple toolboxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,30 @@ Continue? [y/n/v/...? shows all options] (y):
 sh-5.0# vi /media/root/etc/passwd
 ```
 
+### Usage as user
+
+In case an proper user environment is what one wants (e.g., for development), the `-u` (or `--user`) option can be used:
+
+```
+$ id -a
+uid=1000(dario) gid=1000(dario) groups=1000(dario),...
+$ ./toolbox -u
+Spawning a container 'toolbox-dario-user' with image 'registry.opensuse.org/opensuse/toolbox'
+a0a5a332ee6d2a8dff6d8fb68a9ac70aeaacc9d531cf82f610ae48bec9e93ea1
+toolbox-dario-user
+Setting up user 'dario' inside the container...
+Container started successfully. To exit, type 'exit'.
+dario@toolbox:~>
+...
+dario@toolbox:~> id -a
+uid=1000(dario) gid=1000(dario) groups=1000(dario)
+dario@toolbox:~> echo $HOME
+/home/dario
+dario@toolbox:~> ls $HOME/.. -l
+total 0
+drwxr-xr-x 1 dario dario 2422 Feb 14 10:22 dario
+```
+
 ## Advanced Usage
 
 ### Use a custom image

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Spawning a container 'toolbox-dario-user' with image 'registry.opensuse.org/open
 a0a5a332ee6d2a8dff6d8fb68a9ac70aeaacc9d531cf82f610ae48bec9e93ea1
 toolbox-dario-user
 Setting up user 'dario' inside the container...
+(NOTE that, if 'sudo' and related packages are not present in the image already,
+this may take some time. But this will only happen now that the toolbox is being created)
 Container started successfully. To exit, type 'exit'.
 dario@toolbox:~>
 ...
@@ -55,6 +57,36 @@ dario@toolbox:~> echo $HOME
 dario@toolbox:~> ls $HOME/.. -l
 total 0
 drwxr-xr-x 1 dario dario 2422 Feb 14 10:22 dario
+```
+
+The user will have (paswordless) `sudo` access so, e.g., packages can be installed, etc:
+
+```
+$ ./toolbox -u
+Spawning a container 'toolbox-dario-user' with image 'registry.opensuse.org/opensuse/toolbox'
+4a05e36edb55776ae5f32cb736529ba94bdea4a39a8e5d6258ca230f646da733
+toolbox-dario-user
+Setting up user 'dario' (with 'sudo' access) inside the container...
+(NOTE that, if 'sudo' and related packages are not present in the image already,
+this may take some time. But this will only happen now that the toolbox is being created)
+Container started successfully. To exit, type 'exit'.
+dario@toolbox:~>
+...
+dario@toolbox:~> sudo zypper install gcc
+Loading repository data...
+Reading installed packages...
+Resolving package dependencies...
+
+The following 17 NEW packages are going to be installed:
+  binutils cpp cpp9 gcc gcc9 glibc-devel libasan5 libatomic1 libgomp1 libisl22 libitm1 liblsan0 libmpc3 libtsan0 libubsan1 libxcrypt-devel linux-glibc-devel
+
+17 new packages to install.
+Overall download size: 42.6 MiB. Already cached: 0 B. After the operation, additional 179.7 MiB will be used.
+Continue? [y/n/v/...? shows all options] (y):
+...
+dario@toolbox:~> gcc
+gcc: fatal error: no input files
+compilation terminated.
 ```
 
 ## Advanced Usage

--- a/README.md
+++ b/README.md
@@ -107,6 +107,37 @@ IMAGE=opensuse/toolbox:latest
 
 toolbox called by a normal user will start the toolbox container, too, but the root filesystem cannot be modified. Running toolbox with sudo has the disadvantage, that the .toolboxrc from root and not the user is used. To run the toolbox container with root rights, `toolbox --root` has to be used.
 
+### Multiple Toolboxes
+
+It is possible to want to create multiple toolboxes, especially user ones. For instance, one may want to create a special user toolbox, inside which doing development of virtualization related projects. This is possible by adding a tag to a toolbox name, via the `toolbox --tag <tag>` option:
+
+```
+$ podman ps --all
+CONTAINER ID  IMAGE                                                             COMMAND               CREATED             STATUS                         PORTS  NAMES
+b20985e6de68  registry.opensuse.org/opensuse/toolbox:latest                     /bin/bash             57 seconds ago      Exited (0) 3 seconds ago              toolbox-dario-user
+...
+$ ./toolbox -u
+Container 'toolbox-dario-user' already exists. Trying to start...
+(To remove the container and start with a fresh toolbox, run: podman rm 'toolbox-dario-user')
+toolbox-dario-user
+Container started successfully. To exit, type 'exit'.
+...
+$ ./toolbox -u -t virt
+Spawning a container 'toolbox-dario-user-virt' with image 'registry.opensuse.org/opensuse/toolbox'
+0dbfbe02b0201bee9ae3a53c66db70ab621eae914c013e0b2e7a34837adde527
+toolbox-dario-user-virt
+Setting up user 'dario' (with 'sudo' access) inside the container...
+(NOTE that, if 'sudo' and related packages are not present in the image already,
+this may take some time. But this will only happen now that the toolbox is being created)
+Container started successfully. To exit, type 'exit'.
+dario@toolbox:~>
+...
+dario@toolbox:~> exit
+CONTAINER ID  IMAGE                                                             COMMAND               CREATED         STATUS                    PORTS  NAMES
+0dbfbe02b020  registry.opensuse.org/opensuse/toolbox:latest                     /bin/bash             8 minutes ago   Exited (0) 6 minutes ago         toolbox-dario-user-virt
+b20985e6de68  registry.opensuse.org/opensuse/toolbox:latest                     /bin/bash             10 minutes ago  Exited (0) 7 minutes ago         toolbox-dario-user
+```
+
 ### Automatically enter toolbox on login
 
 Set an `/etc/passwd` entry for one of the users to `/usr/bin/toolbox`:

--- a/toolbox
+++ b/toolbox
@@ -50,6 +50,8 @@ run() {
             container_runlabel
             return
         fi
+	# We want to do the user setup only when the container is created for the first time
+	[[ ! -z ${CREATE_AS_USER} ]] && SETUP_USER=true
     else
         echo "Container '$TOOLBOX_NAME' already exists. Trying to start..."
         echo "(To remove the container and start with a fresh toolbox, run: podman rm '$TOOLBOX_NAME')"
@@ -61,6 +63,17 @@ run() {
     elif [[ "$state" != running ]]; then
         echo "Container '$TOOLBOX_NAME' in unknown state: '$state'"
         return 1
+    fi
+
+    if [[ "${SETUP_USER}" = "true" ]]; then
+        echo "Setting up user '${USER_NAME}' inside the container..."
+        cat <<EOF > /tmp/${TOOLBOX_NAME}-user-setup.sh
+#!/bin/bash
+groupadd -g ${USER_GID} ${USER_GNAME} &> /dev/null
+useradd -M -N -g ${USER_GNAME} -u ${USER_ID} ${USER_NAME} &> /dev/null
+EOF
+        ${SUDO} podman cp /tmp/${TOOLBOX_NAME}-user-setup.sh ${TOOLBOX_NAME}:/tmp/user-setup.sh
+        ${SUDO} podman exec --user root ${TOOLBOX_NAME} bash /tmp/user-setup.sh
     fi
 
     echo "Container started successfully. To exit, type 'exit'."

--- a/toolbox
+++ b/toolbox
@@ -149,7 +149,7 @@ container_exec() {
 }
 
 show_help() {
-    echo "USAGE: toolbox [[-h/--help] | [-r/--root] [-u/--user] [command]]
+    echo "USAGE: toolbox [[-h/--help] | [-r/--root] [-u/--user] [-t/--tag <tag>] [command]]
 toolbox is a small script that launches a container to let you bring in your favorite debugging or admin tools.
 The toolbox container is a pet container and will be restarted on following runs.
 To remove the container and start fresh, do podman rm ${TOOLBOX_NAME}.
@@ -158,6 +158,7 @@ Options:
   -h/--help: Shows this help message
   -u/--user: Run as the current user inside the container
   -r/--root: Runs podman via sudo as root
+  -t/--tag <tag>: Add <tag> to the toolbox name
 
 You may override the following variables by setting them in ${TOOLBOXRC}:
 - REGISTRY: The registry to pull from. Default: $REGISTRY
@@ -176,7 +177,7 @@ main() {
     # Execute setup first so we get proper variables
     setup
     # If we are passed a help switch, show help and exit
-    ARGS=`getopt -o hru --long help,root,user -n toolbox -- "$@"`
+    ARGS=`getopt -o hrut: --long help,root,user,tag: -n toolbox -- "$@"`
     eval set -- "$ARGS"
     while true; do
         case "$1" in
@@ -200,6 +201,10 @@ main() {
                 # can modify the user's name, groups, etc, within the container.
                 CREATE_AS_USER="--pid host --userns=keep-id -v ${HOME}:${HOME} --user root:root -w `pwd`"
                 EXEC_AS_USER="--user ${USER_ID}:${USER_GID}"
+                ;;
+            -t|--tag)
+                TOOLBOX_NAME="${TOOLBOX_NAME}-$2"
+                shift 2
                 ;;
             --)
                 shift

--- a/toolbox
+++ b/toolbox
@@ -98,7 +98,7 @@ container_create() {
                  --network host \
                  --privileged \
                  --security-opt label=disable \
-                 --tty \
+                 --tty ${CREATE_AS_USER} \
                  --volume /:/media/root:rslave \
                  "$TOOLBOX_IMAGE" 2>&1; then
         echo "$0: failed to create container '$TOOLBOX_NAME'"
@@ -125,19 +125,20 @@ container_exec() {
             --env LANG="$LANG" \
             --env TERM="$TERM" \
             --interactive \
-            --tty \
+            --tty ${EXEC_AS_USER} \
             "$TOOLBOX_NAME" \
             "$@"
 }
 
 show_help() {
-    echo "USAGE: toolbox [-h/--help]|[-r/--root] [command]
+    echo "USAGE: toolbox [[-h/--help] | [-r/--root] [-u/--user] [command]]
 toolbox is a small script that launches a container to let you bring in your favorite debugging or admin tools.
 The toolbox container is a pet container and will be restarted on following runs.
 To remove the container and start fresh, do podman rm ${TOOLBOX_NAME}.
 
 Options:
   -h/--help: Shows this help message
+  -u/--user: Run as the current user inside the container
   -r/--root: Runs podman via sudo as root
 
 You may override the following variables by setting them in ${TOOLBOXRC}:
@@ -157,7 +158,7 @@ main() {
     # Execute setup first so we get proper variables
     setup
     # If we are passed a help switch, show help and exit
-    ARGS=`getopt -o hr --long help,root -n toolbox -- "$@"`
+    ARGS=`getopt -o hru --long help,root,user -n toolbox -- "$@"`
     eval set -- "$ARGS"
     while true; do
         case "$1" in
@@ -168,6 +169,19 @@ main() {
             -r|--root)
                 shift
                 SUDO=sudo
+                ;;
+            -u|--user)
+                shift
+                USER_ID=`id -u`; USER_GID=`id -g`
+                USER_NAME=`id -un` ; USER_GNAME=`id -gn`
+                USER_HOME=$HOME
+                TOOLBOX_NAME="${TOOLBOX_NAME}-user"
+
+                # We want to keep the pid namespace of the running user.
+                # We, however, use root:root while creating, so that later we
+                # can modify the user's name, groups, etc, within the container.
+                CREATE_AS_USER="--pid host --userns=keep-id -v ${HOME}:${HOME} --user root:root -w `pwd`"
+                EXEC_AS_USER="--user ${USER_ID}:${USER_GID}"
                 ;;
             --)
                 shift

--- a/toolbox
+++ b/toolbox
@@ -66,11 +66,16 @@ run() {
     fi
 
     if [[ "${SETUP_USER}" = "true" ]]; then
-        echo "Setting up user '${USER_NAME}' inside the container..."
+        echo "Setting up user '${USER_NAME}' (with 'sudo' access) inside the container..."
+        echo "(NOTE that, if 'sudo' and related packages are not present in the image already,"
+        echo "this may take some time. But this will only happen now that the toolbox is being created)"
         cat <<EOF > /tmp/${TOOLBOX_NAME}-user-setup.sh
 #!/bin/bash
 groupadd -g ${USER_GID} ${USER_GNAME} &> /dev/null
 useradd -M -N -g ${USER_GNAME} -u ${USER_ID} ${USER_NAME} &> /dev/null
+zypper install -y --no-recommends sudo system-group-wheel &> /dev/null
+echo "%wheel ALL = (root) NOPASSWD:ALL" > /etc/sudoers.d/wheel 2> /dev/null
+usermod -G wheel -a ${USER_NAME} &> /dev/null
 EOF
         ${SUDO} podman cp /tmp/${TOOLBOX_NAME}-user-setup.sh ${TOOLBOX_NAME}:/tmp/user-setup.sh
         ${SUDO} podman exec --user root ${TOOLBOX_NAME} bash /tmp/user-setup.sh

--- a/toolbox
+++ b/toolbox
@@ -157,14 +157,29 @@ main() {
     # Execute setup first so we get proper variables
     setup
     # If we are passed a help switch, show help and exit
-    if [[ "$1" =~ ^(--help|-h)$ ]]; then
-        show_help
-        exit 0
-    fi
-    if [[ "$1" =~ ^(--root|-r)$ ]]; then
-        shift
-	SUDO=sudo
-    fi
+    ARGS=`getopt -o hr --long help,root -n toolbox -- "$@"`
+    eval set -- "$ARGS"
+    while true; do
+        case "$1" in
+            -h|--help)
+                show_help
+                exit 0
+                ;;
+            -r|--root)
+                shift
+                SUDO=sudo
+                ;;
+            --)
+                shift
+                break
+                ;;
+            *)
+                echo "unknown parameter: '$1'"
+                show_help
+                exit 1
+                ;;
+        esac
+    done
 
     if [ -z "$*" ]; then
 	run ${TOOLBOX_SHELL}


### PR DESCRIPTION
In my daily development work, I deal with several projects. It happens that I make changes to the sources of these projects, which I then may want to (at least) build test locally. For building such projects I need their build dependencies installed on my workstation and such list. And the list of required packages may be quite long (from stuff like gcc, make, flex, bison, etc. to things like `bc`,  libyajl-devel, libSDL2-devel and so on and so forth.

Now, on a, MicroOS based, immutable rootfs workstation, I definitely would not want to have all those packages installed on the main OS, for obvious reasons. The idea would be to build and test my work in containers, and that is similar to what toolbox does already.

However:
- I'd need a container inside which the home directory of my main OS user (where I, and presumably most people too, keep the sources) is there and is easily accessible at its standard path (e.g., in /home/dario). In fact, it may be the case that build time paths matter for either building, testing, etc;
- I'd prefer to be a regular user inside such a container, even if I know how toolbox maps the root user in the container. E.g., although I can't name one out of the top of my head, I've definitely seen projects that complain if you try to build or run them as root;
- I may want to build each project (or maybe a specific set of projects, with similar scope and/or dependency) in their own container. This means being able to manage multiple toolboxes (i.e., multiple toolbox containers) per user.