### PR TITLE
fix entering a toolbox if something changed in /dev since creation

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -115,10 +115,10 @@ container_create() {
                  --name "$TOOLBOX_NAME" \
                  --network host \
                  --privileged \
-                 --security-opt label=disable \
-                 --tty ${CREATE_AS_USER} \
+                 --security-opt label=disable ${CREATE_AS_USER} \
                  --volume /:/media/root:rslave \
-                 "$TOOLBOX_IMAGE" 2>&1; then
+		 --volume /dev:/dev:rslave \
+                 "$TOOLBOX_IMAGE" sleep +Inf 2>&1; then
         echo "$0: failed to create container '$TOOLBOX_NAME'"
         exit 1
     fi


### PR DESCRIPTION
As described by this libpod issue:

https://github.com/containers/libpod/issues/4900

a rootless privileged container refuses to start if anything
has changed in the host device layout since the container
creation.

Using '-v /dev:/dev:rslave' helps, but then we run into
this other issue (about tty permissions):

https://github.com/containers/crun/issues/150

Fix that too by slightly changing container creation.

Using 'sleep +Inf' comes from Fedora Silverblue
toolbox.

This was described in our issue:
https://github.com/kubic-project/microos-toolbox/issues/3

Signed-off-by: Dario Faggioli <dfaggioli@suse.com>