### PR TITLE
Usability enhancements for user toolboxes

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -199,8 +199,8 @@ main() {
                 # We want to keep the pid namespace of the running user.
                 # We, however, use root:root while creating, so that later we
                 # can modify the user's name, groups, etc, within the container.
-                CREATE_AS_USER="--pid host --userns=keep-id -v ${HOME}:${HOME} --user root:root -w `pwd`"
-                EXEC_AS_USER="--user ${USER_ID}:${USER_GID}"
+                CREATE_AS_USER="--pid host --userns=keep-id -v ${HOME}:${HOME} --user root:root"
+                EXEC_AS_USER="--user ${USER_ID}:${USER_GID} -w `pwd`"
                 ;;
             -t|--tag)
                 TOOLBOX_NAME="${TOOLBOX_NAME}-$2"

--- a/toolbox
+++ b/toolbox
@@ -111,7 +111,7 @@ image_pull() {
 
 container_create() {
     if ! ${SUDO} podman create \
-                 --hostname toolbox \
+                 --hostname "$TOOLBOX_NAME" \
                  --name "$TOOLBOX_NAME" \
                  --network host \
                  --privileged \

--- a/toolbox
+++ b/toolbox
@@ -199,8 +199,8 @@ main() {
                 # We want to keep the pid namespace of the running user.
                 # We, however, use root:root while creating, so that later we
                 # can modify the user's name, groups, etc, within the container.
-                CREATE_AS_USER="--pid host --userns=keep-id -v ${HOME}:${HOME} --user root:root"
-                EXEC_AS_USER="--user ${USER_ID}:${USER_GID} -w `pwd`"
+                CREATE_AS_USER="--pid host --userns=keep-id -v ${HOME}:${HOME} --user root:root --volume /run/user/${USER_ID}:/run/user/${USER_ID}:rslave "
+                EXEC_AS_USER="--user ${USER_ID}:${USER_GID} -w `pwd` --env SSH_AUTH_SOCK=$SSH_AUTH_SOCK"
                 ;;
             -t|--tag)
                 TOOLBOX_NAME="${TOOLBOX_NAME}-$2"


### PR DESCRIPTION
Some minor changes to how a user toolbox is created and/or started. These result in things such as:
- user toolboxes have their own custom hostname, so one can always immediately tell in which toolbox he/she is (in case there are many);
- the user enters the toolbox and stays in the same directory where he/she was on the host;
- SSH agent works inside a user toolbox, so we don't have to re-type passwords over and over.

When extensively using user toolboxes, like for day to day development, these are quite substantial usability improvements.