### PR TITLE
Allow graphical applications from inside a user toolbox to run

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -200,7 +200,7 @@ main() {
                 # We, however, use root:root while creating, so that later we
                 # can modify the user's name, groups, etc, within the container.
                 CREATE_AS_USER="--pid host --userns=keep-id -v ${HOME}:${HOME} --user root:root --volume /run/user/${USER_ID}:/run/user/${USER_ID}:rslave "
-                EXEC_AS_USER="--user ${USER_ID}:${USER_GID} -w `pwd` --env SSH_AUTH_SOCK=$SSH_AUTH_SOCK"
+                EXEC_AS_USER="--user ${USER_ID}:${USER_GID} -w `pwd` --env SSH_AUTH_SOCK=$SSH_AUTH_SOCK --env DISPLAY=$DISPLAY --env XAUTHORITY=$XAUTHORITY"
                 ;;
             -t|--tag)
                 TOOLBOX_NAME="${TOOLBOX_NAME}-$2"


### PR DESCRIPTION
It can happen that some user needs to quickly install and run
applications with a graphical interface, especially from user toolboxes.
That currently does not work, but making it working is just a matter of
exporting to the container a couple of env variables... So let's go for
it.

Another use case is when one use user toolboxes for some specific
tasks, such as development, testing or whatever. E.g., it would be quite
useful to build your application inside a toolbox (where you keep all
the dev and build tools and dependencies installed), and also be able to
test-run it, even if it is a graphical app.

Signed-off-by: Dario Faggioli <dfaggioli@suse.com>