### PR TITLE
Make it easier to use custom images

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ On systems using `transactional-update` it is not really possible - due to the r
 The following options are avialbe in `toolbox`:
 * `-h` or `--help`: Shows the help message
 * `-u` or `--user`: Run as the current user inside the container
+* `-R` or `--registry` `<registry>`: Explicitly specify the registry to use
+* `-I` or `--image` `<image>`: Explicitly specify the image to pull
 * `-r` or `--root`: Runs podman via sudo as root
 * `-t` or `--tag` <tag>: Add <tag> to the toolbox name
     
@@ -22,6 +24,9 @@ Example toolboxrc:
 * `IMAGE`=debug:latest
 * `TOOLBOX_NAME`=special-debug-container
 * `TOOLBOX_SHELL`=/bin/bash"
+
+If a config file is found, with REGISTRY and IMAGE defined, "${REGISTRY}/${IMAGE}" is used, overriding the default.
+If -R and/or -I is/are used they override both the defaults and the content of REGISTRY and/or IMAGE from the config file.
 
 ### Rootfull Usage Example
 

--- a/toolbox
+++ b/toolbox
@@ -177,7 +177,7 @@ main() {
     # Execute setup first so we get proper variables
     setup
     # If we are passed a help switch, show help and exit
-    ARGS=`getopt -o hrut: --long help,root,user,tag: -n toolbox -- "$@"`
+    ARGS=`getopt -o hrut:R:I: --long help,root,user,tag:,registry:,image: -n toolbox -- "$@"`
     eval set -- "$ARGS"
     while true; do
         case "$1" in
@@ -204,6 +204,18 @@ main() {
                 ;;
             -t|--tag)
                 TOOLBOX_NAME="${TOOLBOX_NAME}-$2"
+                shift 2
+                ;;
+            -R|--registry)
+                REGISTRY=$2
+                # Let's rebuild the image URI (this means that command
+                # line, if present, overrides config file)
+                TOOLBOX_IMAGE="${REGISTRY}"/"${IMAGE}"
+                shift 2
+                ;;
+            -I|--image)
+                IMAGE=$2
+                TOOLBOX_IMAGE="${REGISTRY}"/"${IMAGE}"
                 shift 2
                 ;;
             --)

--- a/toolbox
+++ b/toolbox
@@ -73,7 +73,7 @@ run() {
 #!/bin/bash
 groupadd -g ${USER_GID} ${USER_GNAME} &> /dev/null
 useradd -M -N -g ${USER_GNAME} -u ${USER_ID} ${USER_NAME} &> /dev/null
-zypper install -y --no-recommends sudo system-group-wheel &> /dev/null
+getent group wheel >/dev/null || zypper install -y --no-recommends sudo system-group-wheel &> /dev/null
 echo "%wheel ALL = (root) NOPASSWD:ALL" > /etc/sudoers.d/wheel 2> /dev/null
 usermod -G wheel -a ${USER_NAME} &> /dev/null
 EOF

--- a/toolbox
+++ b/toolbox
@@ -69,7 +69,8 @@ run() {
         echo "Setting up user '${USER_NAME}' (with 'sudo' access) inside the container..."
         echo "(NOTE that, if 'sudo' and related packages are not present in the image already,"
         echo "this may take some time. But this will only happen now that the toolbox is being created)"
-        cat <<EOF > /tmp/${TOOLBOX_NAME}-user-setup.sh
+        local tmp_user_setup=`mktemp ${HOME}/.${TOOLBOX_NAME}-user-setup-XXXXXX.sh`
+        cat <<EOF > ${tmp_user_setup}
 #!/bin/bash
 groupadd -g ${USER_GID} ${USER_GNAME} &> /dev/null
 useradd -M -N -g ${USER_GNAME} -u ${USER_ID} ${USER_NAME} &> /dev/null
@@ -77,8 +78,9 @@ getent group wheel >/dev/null || zypper install -y --no-recommends sudo system-g
 echo "%wheel ALL = (root) NOPASSWD:ALL" > /etc/sudoers.d/wheel 2> /dev/null
 usermod -G wheel -a ${USER_NAME} &> /dev/null
 EOF
-        ${SUDO} podman cp /tmp/${TOOLBOX_NAME}-user-setup.sh ${TOOLBOX_NAME}:/tmp/user-setup.sh
-        ${SUDO} podman exec --user root ${TOOLBOX_NAME} bash /tmp/user-setup.sh
+        ${SUDO} podman cp ${tmp_user_setup} ${TOOLBOX_NAME}:${tmp_user_setup}
+        ${SUDO} podman exec --user root ${TOOLBOX_NAME} bash ${tmp_user_setup}
+        ${SUDO} podman exec --user root ${TOOLBOX_NAME} rm ${tmp_user_setup}
     fi
 
     echo "Container started successfully. To exit, type 'exit'."


### PR DESCRIPTION
if I want to create a development (or whatever kind of) toolbox that uses a certain custom image, e.g., one that I have done for myself such as registry.opensuse.org/home/dfaggioli/branches/opensuse/templates/images/tumbleweed/images/opensuse/toolbox-dario-dev:latest just once for once, it's quite annoying to have to edit the config file itself for creating just that one toolbox and then edit it again for putting back the default (with which I'm fine with the rest of the times.

Let's make that easier with some by adding some parameters.

While there, let's also speed up the users' toolbox creation, in case the image used already contains the special package we need (system-group-wheel).
