### PR TITLE
Env-s, bind-mounts and UI compatibility with Silverblue toolbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # toolbox - bring your own tools with you
 
 On systems using `transactional-update` it is not really possible - due to the read-only root filesystem - to install tools to analyze problems in the currently running system as a reboot is always required. This makes it next to impossible to debug such problems.
-`toolbox` is a small script that launches a podman container in a rootless or rootfull state to let you bring in your favorite debugging or admin tools in such a system. You can also install and run GUI applications in your `toolbox` container. The root filesystem can be found at `/media/root`.
+`toolbox` is a small script that launches a podman container in a rootless or rootfull state to let you bring in your favorite debugging or admin tools in such a system.
+
+You can also install and run GUI applications in your `toolbox` container. The root filesystem can be found at `/media/root`. In a "user toolbox" (i.e., one started with `toolbox -u`) the user's home directory is available in the usual place (`/home/$USER`).
 
 ## Usage     
      
@@ -13,93 +15,95 @@ The following options are avialbe in `toolbox`:
 * `-r` or `--root`: Runs podman via sudo as root
 * `-t` or `--tag` <tag>: Add <tag> to the toolbox name
     
-You may override the following variables by setting them in ${TOOLBOXRC}:
-* REGISTRY: The registry to pull from. Default value is: `registry.opensuse.org`.
-* IMAGE: The image and tag from the registry to pull. Default value is: `opensuse/toolbox`.
-* TOOLBOX_NAME: The name to use for the local container. Default value is: `"${HOME}"/.toolboxrc`.
-* TOOLBOX_SHELL: Standard shell if no other commands are given. Default value is: `/bin/bash`.
+You may override the following variables by setting them in `${HOME}/.toolboxrc`:
+* `REGISTRY`: The registry to pull from. Default value is: `registry.opensuse.org`.
+* `IMAGE`: The image and tag from the registry to pull. Default value is: `opensuse/toolbox`.
+* `TOOLBOX_NAME`: The name to use for the local container. Default value is: `toolbox-${USER}`.
+* `TOOLBOX_SHELL`: Standard shell if no other commands are given. Default value is: `/bin/bash`.
 
-Example toolboxrc:
-* `REGISTRY`=my.special.registry.example.com
-* `IMAGE`=debug:latest
-* `TOOLBOX_NAME`=special-debug-container
-* `TOOLBOX_SHELL`=/bin/bash"
-
-If a config file is found, with REGISTRY and IMAGE defined, "${REGISTRY}/${IMAGE}" is used, overriding the default.
-If -R and/or -I is/are used they override both the defaults and the content of REGISTRY and/or IMAGE from the config file.
-
-### Rootfull Usage Example
-
+Example `.toolboxrc` file:
 ```
-$ /usr/bin/toolbox
-Spawning a container 'toolbox-root' with image 'registry.opensuse.org/opensuse/toolbox'
-51e475f05d8bb8a5bf110bbecd960383bf8cfade1569587edef92076215f0eba
-toolbox-root
-Container started successfully. To exit, type 'exit'.
-sh-5.0# ls -alF /media/root
-...
-sh-5.0# tcpdump -i ens3
-tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
-listening on ens3, link-type EN10MB (Ethernet), capture size 65535 bytes
-...
-sh-5.0# zypper in vim
-Loading repository data...
-Reading installed packages...
-Resolving package dependencies...
-
-The following 5 NEW packages are going to be installed:
-  libgdbm6 libgdbm_compat4 perl vim vim-data-common
-
-5 new packages to install.
-Overall download size: 9.0 MiB. Already cached: 0 B. After the operation,
-additional 49.4 MiB will be used.
-Continue? [y/n/v/...? shows all options] (y):
-...
-sh-5.0# vi /media/root/etc/passwd
+REGISTRY=my.special.registry.example.com
+IMAGE=debug:latest
+TOOLBOX_NAME=special-debug-container
+TOOLBOX_SHELL=/bin/bash
 ```
 
-## Rootless Usage 
+If a config file is found, with `REGISTRY` and `IMAGE` defined, `${REGISTRY}/${IMAGE}` is used, overriding the default.
+If `-R` and/or `-I` is/are used they override both the defaults and the content of `REGISTRY` and/or `IMAGE` from the config file.
+
+### Rootless Usage
+
+By default a toolbox is a rootless container. This means that being root inside the toolbox itself does not map with being root on the host,
+e.g., as far as file permissions, access to special files, etc go.
+
+#### Rootless Usage Example
+
+```
+$ id
+uid=1000(dario) gid=100(users) groups=100(users),496(wheel),1000(dario)
+$ toolbox
+.toolboxrc file detected, overriding defaults...
+Container 'toolbox-dario' already exists. Trying to start...
+(To remove the container and start with a fresh toolbox, run: podman rm 'toolbox-dario')
+toolbox-dario
+Container started.
+Entering container. To exit, type 'exit'.
+...
+toolbox-dario:/ # id
+uid=0(root) gid=0(root) groups=0(root)
+toolbox-dario:/ # ls -alF /media/root
+total 88
+drwxr-xr-x   1 65534 65534   256 Sep 12 10:33 ./
+drwxr-xr-x   3 root  root     48 Jan 20 14:06 ../
+drwxr-xr-x   1 65534 65534  1674 Dec 17 02:17 bin/
+drwxr-xr-x   1 65534 65534   554 Jan 18 10:44 boot/
+drwxr-xr-x  22 65534 65534  4300 Jan 19 22:22 dev/
+...
+toolbox-dario:/ # tcpdump -i em1
+tcpdump: em1: You don't have permission to capture on that device
+(socket: Operation not permitted)
+...
+toolbox-dario:/ # touch /media/root/etc/foo
+touch: cannot touch '/media/root/etc/foo': Permission denied
+```
+
+#### Rootless Usage Example, With User Setup
 
 In case a proper user environment is what one wants (e.g., for development), the `-u` (or `--user`) option can be used:
-
-### Rootless Usage Example
 
 ```
 $ id -a
 uid=1000(dario) gid=1000(dario) groups=1000(dario),...
-$ ./toolbox -u
-Spawning a container 'toolbox-dario-user' with image 'registry.opensuse.org/opensuse/toolbox'
-a0a5a332ee6d2a8dff6d8fb68a9ac70aeaacc9d531cf82f610ae48bec9e93ea1
+$ toolbox -u
+.toolboxrc file detected, overriding defaults...
+Container 'toolbox-dario-user' already exists. Trying to start...
+(To remove the container and start with a fresh toolbox, run: podman rm 'toolbox-dario-user')
 toolbox-dario-user
-Setting up user 'dario' inside the container...
-(NOTE that, if 'sudo' and related packages are not present in the image already,
-this may take some time. But this will only happen now that the toolbox is being created)
-Container started successfully. To exit, type 'exit'.
-dario@toolbox:~>
+Container started.
+Entering container. To exit, type 'exit'.
+dario@toolbox-dario-user:~> id
+uid=1000(dario) gid=100(users) groups=100(users)
 ...
-dario@toolbox:~> id -a
-uid=1000(dario) gid=1000(dario) groups=1000(dario)
-dario@toolbox:~> echo $HOME
+dario@toolbox-dario-user:~> echo $HOME
 /home/dario
-dario@toolbox:~> ls $HOME/.. -l
+dario@toolbox-dario-user:~> ls -l /home
 total 0
-drwxr-xr-x 1 dario dario 2422 Feb 14 10:22 dario
+drwxr-xr-x 1 dario users 2290 Jan 20 14:33 dario
 ```
 
 The user will have (paswordless) `sudo` access so, e.g., packages can be installed, etc:
 
 ```
 $ ./toolbox -u
-Spawning a container 'toolbox-dario-user' with image 'registry.opensuse.org/opensuse/toolbox'
-4a05e36edb55776ae5f32cb736529ba94bdea4a39a8e5d6258ca230f646da733
+.toolboxrc file detected, overriding defaults...
+Container 'toolbox-dario-user' already exists. Trying to start...
+(To remove the container and start with a fresh toolbox, run: podman rm 'toolbox-dario-user')
 toolbox-dario-user
-Setting up user 'dario' (with 'sudo' access) inside the container...
-(NOTE that, if 'sudo' and related packages are not present in the image already,
-this may take some time. But this will only happen now that the toolbox is being created)
-Container started successfully. To exit, type 'exit'.
-dario@toolbox:~>
+Container started.
+Entering container. To exit, type 'exit'.
 ...
-dario@toolbox:~> sudo zypper install gcc
+dario@toolbox-dario-user:~> sudo zypper in gcc
 Loading repository data...
 Reading installed packages...
 Resolving package dependencies...
@@ -111,12 +115,101 @@ The following 17 NEW packages are going to be installed:
 Overall download size: 42.6 MiB. Already cached: 0 B. After the operation, additional 179.7 MiB will be used.
 Continue? [y/n/v/...? shows all options] (y):
 ...
-dario@toolbox:~> gcc
-gcc: fatal error: no input files
-compilation terminated.
+dario@toolbox-dario-user:~> which gcc
+/usr/bin/gcc
+...
+dario@toolbox-dario-user:~> sudo tcpdump -i em1
+tcpdump: em1: You don't have permission to capture on that device
+(socket: Operation not permitted)
+```
+
+### Rootful Usage
+
+In fact, toolbox called by a normal user will start the toolbox container but the root filesystem of the host cannot be modified, special devices cannot be accessed, etc.
+Running toolbox with sudo has the disadvantage, that the `.toolboxrc` in the `root` user home directory, and not the user's, is used.
+To run the toolbox container with root rights, `toolbox --root` (or `-r`) has to be used.
+
+#### Rootfull Usage Example
+
+```
+$ id
+uid=1000(dario) gid=100(users) groups=100(users),496(wheel),1000(dario)
+$ toolbox -r
+.toolboxrc file detected, overriding defaults...
+Spawning a container 'toolbox-dario' with image 'registry.opensuse.org/opensuse/toolbox'
+08a8b984be2430a5d2cb38d55b26a93ddda3e5e5d183fbb75ac7287421a3f8be
+toolbox-dario
+Container created.
+Entering container. To exit, type 'exit'.
+...
+toolbox-dario:/ # id
+uid=0(root) gid=0(root) groups=0(root)
+toolbox-dario:/ # ls -alF /media/root
+total 88
+drwxr-xr-x   1 root root   256 Sep 12 10:33 ./
+drwxr-xr-x   1 root root     8 Jan 20 13:51 ../
+drwxr-xr-x   1 root root  1674 Dec 17 02:17 bin/
+drwxr-xr-x   1 root root   554 Jan 18 10:44 boot/
+drwxr-xr-x  22 root root  4300 Jan 19 22:22 dev/
+...
+toolbox-dario:/ # tcpdump -i em1
+tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
+listening on em1, link-type EN10MB (Ethernet), capture size 262144 bytes
+13:54:52.843421 IP 192.168.0.9.46690 > 192.168.0.255.32412: UDP, length 21
+13:54:52.843655 IP 192.168.0.9.59404 > 192.168.0.255.32414: UDP, length 21
+...
+toolbox-dario:/ # touch /media/root/etc/foo
+toolbox-dario:/ # ls -la /media/root/etc/foo
+-rw-r--r-- 1 root root 0 Jan 20 14:09 /media/root/etc/foo
 ```
 
 ## Advanced Usage
+
+### Running a command/program inside a toolbox
+
+By default, toolbox drops the user into a shell, inside the container. It is possible, instead, to launch a specific command or program inside of the container:
+
+```
+$ toolbox -u sudo zypper in figlet
+.toolboxrc file detected, overriding defaults...
+Container 'toolbox-dario-user' already exists. Trying to start...
+(To remove the container and start with a fresh toolbox, run: podman rm 'toolbox-dario-user')
+toolbox-dario-user
+Container started.
+Entering container. To exit, type 'exit'.
+Loading repository data...
+Reading installed packages...
+Resolving package dependencies...
+
+The following NEW package is going to be installed:
+  figlet
+
+1 new package to install.
+Overall download size: 3.0 MiB. Already cached: 0 B. After the operation, additional 75.2 MiB will be used.
+Continue? [y/n/v/...? shows all options] (y):
+...
+...
+$ toolbox -u figlet Hey from toolbox!
+.toolboxrc file detected, overriding defaults...
+Container 'toolbox-dario-user' already exists. Trying to start...
+(To remove the container and start with a fresh toolbox, run: podman rm 'toolbox-dario-user')
+toolbox-dario-user
+Container started.
+Entering container. To exit, type 'exit'.
+ _   _               __
+| | | | ___ _   _   / _|_ __ ___  _ __ ___  
+| |_| |/ _ \ | | | | |_| '__/ _ \| '_ ` _ \ 
+|  _  |  __/ |_| | |  _| | | (_) | | | | | |
+|_| |_|\___|\__, | |_| |_|  \___/|_| |_| |_|
+            |___/
+ _              _ _               _
+| |_ ___   ___ | | |__   _____  _| |
+| __/ _ \ / _ \| | '_ \ / _ \ \/ / |
+| || (_) | (_) | | |_) | (_) >  <|_|
+ \__\___/ \___/|_|_.__/ \___/_/\_(_)
+```
+
+Of course, the command to run could even be a shell. However, for using a different shell than the default one inside of the toolbox, it is also possible to change the value of the `TOOLBOX_SHELL` variable within the config file.
 
 ### Use a custom image
 
@@ -129,10 +222,6 @@ toolbox uses an openSUSE-based userspace environment called `opensuse/toolbox` b
 REGISTRY=registry.opensuse.org
 IMAGE=opensuse/toolbox:latest
 ```
-
-### Root container as normal user
-
-toolbox called by a normal user will start the toolbox container, too, but the root filesystem cannot be modified. Running toolbox with sudo has the disadvantage, that the .toolboxrc from root and not the user is used. To run the toolbox container with root rights, `toolbox --root` has to be used.
 
 ### Multiple Toolboxes
 
@@ -148,6 +237,9 @@ Container 'toolbox-dario-user' already exists. Trying to start...
 (To remove the container and start with a fresh toolbox, run: podman rm 'toolbox-dario-user')
 toolbox-dario-user
 Container started successfully. To exit, type 'exit'.
+dario@toolbox-dario-user:~>
+...
+dario@toolbox-dario-user:~> exit
 ...
 $ ./toolbox -u -t virt
 Spawning a container 'toolbox-dario-user-virt' with image 'registry.opensuse.org/opensuse/toolbox'
@@ -157,9 +249,9 @@ Setting up user 'dario' (with 'sudo' access) inside the container...
 (NOTE that, if 'sudo' and related packages are not present in the image already,
 this may take some time. But this will only happen now that the toolbox is being created)
 Container started successfully. To exit, type 'exit'.
-dario@toolbox:~>
+dario@toolbox-dario-user-virt:~>
 ...
-dario@toolbox:~> exit
+dario@toolbox-dario-user-virt:~> exit
 CONTAINER ID  IMAGE                                                             COMMAND               CREATED         STATUS                    PORTS  NAMES
 0dbfbe02b020  registry.opensuse.org/opensuse/toolbox:latest                     /bin/bash             8 minutes ago   Exited (0) 6 minutes ago         toolbox-dario-user-virt
 b20985e6de68  registry.opensuse.org/opensuse/toolbox:latest                     /bin/bash             10 minutes ago  Exited (0) 7 minutes ago         toolbox-dario-user
@@ -183,16 +275,19 @@ Container 'toolbox-bob' already exists. Trying to start...
 (To remove the container and start with a fresh toolbox, run: podman rm 'toolbox-bob')
 toolbox-bob
 Container started successfully. To exit, type 'exit'.
-sh-5.0#
+toolbox-bob:/ #
 ```
 
 ## Troubleshooting
 
-#### Podman can't pull/run images with user
+### Podman can't pull/run images with user
 If you want to run a rootless `toolbox` setup you might need to add a range of UID and GID for the user you want to run `toolbox` with. Before adding UID and GID ranges check if `/etc/subuid` and `/etc/subgid` are actually empty. If empty you can run this as root to populate them:   
+
 ```
 echo "podman_user:100000:65536" > /etc/subuid
 echo "podman_user:100000:65536" > /etc/subgid
 ```
-#### GUI application can't connect to display 
-This happens if you run the container as root - with sudo for example - while you're logged in as user to the desktop environment. The easiest way is to use `toolbox -u` with your user to setup a `rootless toolbox`  container for such cases. 
+
+### GUI application can't connect to display 
+
+This happens if you run the container as root - with sudo for example - while you're logged in as user to the desktop environment. The easiest way is to use `toolbox -u` with your user to setup a "rootless toolbox"  container for such cases.

--- a/toolbox
+++ b/toolbox
@@ -187,7 +187,9 @@ container_exec() {
 }
 
 show_help() {
-    echo "USAGE: toolbox [[-h/--help] | [command] [-r/--root] [-u/--user] [-t/--tag <tag>] [command_to_run]]
+    echo "USAGE: toolbox [[-h/--help] | [command] [-r/--root] [-u/--user]
+        [[-R/--reg <registry>] [-I/--img <image>]|[-i/--image <image_URI>]]
+        [[-t/--tag <tag>]|[-c/--container <name>]] [command_to_run]]
 toolbox is a small script that launches a container to let you bring in your favorite debugging or admin tools.
 The toolbox container is a pet container and will be restarted on following runs.
 To remove the container and start fresh, do podman rm ${TOOLBOX_NAME}.
@@ -203,6 +205,12 @@ Options:
   -u/--user: Run as the current user inside the container
   -r/--root: Runs podman via sudo as root
   -t/--tag <tag>: Add <tag> to the toolbox name
+  -c/--container <name>: Set the name of the toolbox to be equal to <name>
+                         (use this alternatively to -t)
+  -R/--reg <registry>: Pulls the container image from <registry>
+  -I/--img <image>: Pulls the image called <image>
+  -i/--image <image_URI>: Pulls <image_URI> as a container image (use this
+                          alternatively to -R and -I)
 
 You may override the following variables by setting them in ${TOOLBOXRC}:
 - REGISTRY: The registry to pull from. Default: $REGISTRY
@@ -248,7 +256,7 @@ main() {
         esac
     fi
 
-    ARGS=`getopt -o hrut:R:I: --long help,root,user,tag:,registry:,image: -n toolbox -- "$@"`
+    ARGS=`getopt -o hrut:R:I:c:i: --long help,root,user,tag:,reg:,img:,container:,image: -n toolbox -- "$@"`
     eval set -- "$ARGS"
     while true; do
         case "$1" in
@@ -265,20 +273,36 @@ main() {
                 shift
 		MODE="user"
                 ;;
+            -c|--container)
+                if [ ! -z $TAG ]; then
+                    echo "ERROR: Don't use both -c and -t!"
+                    show_help
+                    exit 1
+                fi
+                CHANGE_NAME="true"
+                TOOLBOX_NAME="$2"
+                shift 2
+                ;;
             -t|--tag)
+                if [ ! -z $CHANGE_NAME ]; then
+                    echo "ERROR: Don't use both -c and -t!"
+                    show_help
+                    exit 1
+                fi
                 TAG="$2"
                 shift 2
                 ;;
-            -R|--registry)
+            -R|--reg)
                 REGISTRY=$2
-                # Let's rebuild the image URI (this means that command
-                # line, if present, overrides config file)
-                TOOLBOX_IMAGE="${REGISTRY}"/"${IMAGE}"
                 shift 2
                 ;;
-            -I|--image)
+            -I|--img)
                 IMAGE=$2
-                TOOLBOX_IMAGE="${REGISTRY}"/"${IMAGE}"
+                shift 2
+                ;;
+            -i|--image)
+                REGISTRY=""
+                IMAGE=$2
                 shift 2
                 ;;
             --)
@@ -293,11 +317,17 @@ main() {
         esac
     done
 
+    # Let's rebuild the image URI (this means that command
+    # line, if present, overrides config file)
+    TOOLBOX_IMAGE=`echo "${REGISTRY}"/"${IMAGE}" | sed 's/^\///g'`
+
     if [ "$MODE" = "user" ]; then
         USER_ID=`id -u`; USER_GID=`id -g`
         USER_NAME=`id -un` ; USER_GNAME=`id -gn`
         USER_HOME=$HOME
-        TOOLBOX_NAME="${TOOLBOX_NAME}-user"
+	if [ -z $CHANGE_NAME ]; then
+            TOOLBOX_NAME="${TOOLBOX_NAME}-user"
+        fi
 
         # We want to keep the pid namespace of the running user.
         # We, however, use root:root while creating, so that later we

--- a/toolbox
+++ b/toolbox
@@ -223,7 +223,7 @@ main() {
                 # We want to keep the pid namespace of the running user.
                 # We, however, use root:root while creating, so that later we
                 # can modify the user's name, groups, etc, within the container.
-                CREATE_AS_USER="--pid host --userns=keep-id -v ${HOME}:${HOME} --user root:root --volume /run/user/${USER_ID}:/run/user/${USER_ID}:rslave "
+                CREATE_AS_USER="--pid host --userns=keep-id -v ${HOME}:${HOME} --user root:root --volume /run/user/${USER_ID}:/run/user/${USER_ID}:rslave --volume /run/media/:/run/media/:rslave --volume /tmp:/tmp:rslave"
                 for ENV in $USER_ENV ; do
                     eval VAL="$""$ENV"
                     [[ ! -z $VAL ]] && USER_ENV_STR="$USER_ENV_STR --env $ENV=$VAL"

--- a/toolbox
+++ b/toolbox
@@ -28,6 +28,26 @@ SUDO=
 
 test -f /etc/toolboxrc && . /etc/toolboxrc
 
+USER_ENV="DBUS_SESSION_BUS_ADDRESS \
+    DBUS_SYSTEM_BUS_ADDRESS \
+    DESKTOP_SESSION \
+    SESSION_MANAGER \
+    DISPLAY \
+    LANG \
+    SSH_AUTH_SOCK \
+    USER \
+    USERNAME \
+    WAYLAND_DISPLAY \
+    XAUTHORITY \
+    XAUTHLOCALHOSTNAME \
+    XDG_CURRENT_DESKTOP \
+    XDG_DATA_DIRS \
+    XDG_MENU_PREFIX \
+    XDG_RUNTIME_DIR \
+    XDG_SESSION_CLASS \
+    XDG_SESSION_DESKTOP \
+    XDG_SESSION_TYPE"
+
 setup() {
     # Allow user overrides
     if [ -f "${TOOLBOXRC}" ]; then
@@ -204,7 +224,11 @@ main() {
                 # We, however, use root:root while creating, so that later we
                 # can modify the user's name, groups, etc, within the container.
                 CREATE_AS_USER="--pid host --userns=keep-id -v ${HOME}:${HOME} --user root:root --volume /run/user/${USER_ID}:/run/user/${USER_ID}:rslave "
-                EXEC_AS_USER="--user ${USER_ID}:${USER_GID} -w `pwd` --env SSH_AUTH_SOCK=$SSH_AUTH_SOCK --env DISPLAY=$DISPLAY --env XAUTHORITY=$XAUTHORITY"
+                for ENV in $USER_ENV ; do
+                    eval VAL="$""$ENV"
+                    [[ ! -z $VAL ]] && USER_ENV_STR="$USER_ENV_STR --env $ENV=$VAL"
+                done
+                EXEC_AS_USER="--user ${USER_ID}:${USER_GID} -w `pwd` $USER_ENV_STR"
                 ;;
             -t|--tag)
                 TOOLBOX_NAME="${TOOLBOX_NAME}-$2"

--- a/toolbox
+++ b/toolbox
@@ -28,6 +28,8 @@ SUDO=
 
 test -f /etc/toolboxrc && . /etc/toolboxrc
 
+MODE="system"
+
 USER_ENV="DBUS_SESSION_BUS_ADDRESS \
     DBUS_SYSTEM_BUS_ADDRESS \
     DESKTOP_SESSION \
@@ -57,11 +59,12 @@ setup() {
     TOOLBOX_IMAGE="${REGISTRY}"/"${IMAGE}"
 }
 
-run() {
+create() {
     if ! image_exists; then
         image_pull
     fi
 
+    local msg="creat"
     local runlabel=$(image_runlabel)
     if ! container_exists; then
         echo "Spawning a container '$TOOLBOX_NAME' with image '$TOOLBOX_IMAGE'"
@@ -77,6 +80,7 @@ run() {
     else
         echo "Container '$TOOLBOX_NAME' already exists. Trying to start..."
         echo "(To remove the container and start with a fresh toolbox, run: podman rm '$TOOLBOX_NAME')"
+	msg="start"
     fi
 
     local state=$(container_state)
@@ -105,7 +109,13 @@ EOF
         ${SUDO} podman exec --user root ${TOOLBOX_NAME} rm ${tmp_user_setup}
     fi
 
-    echo "Container started successfully. To exit, type 'exit'."
+    echo "Container ${msg}ed."
+}
+
+run() {
+    create
+
+    echo "Entering container. To exit, type 'exit'."
     container_exec "$@"
 }
 
@@ -131,6 +141,10 @@ image_runlabel() {
 
 image_pull() {
     ${SUDO} podman pull "$TOOLBOX_IMAGE"
+}
+
+list() {
+    ${SUDO} podman ps --all
 }
 
 container_create() {
@@ -173,10 +187,16 @@ container_exec() {
 }
 
 show_help() {
-    echo "USAGE: toolbox [[-h/--help] | [-r/--root] [-u/--user] [-t/--tag <tag>] [command]]
+    echo "USAGE: toolbox [[-h/--help] | [command] [-r/--root] [-u/--user] [-t/--tag <tag>] [command_to_run]]
 toolbox is a small script that launches a container to let you bring in your favorite debugging or admin tools.
 The toolbox container is a pet container and will be restarted on following runs.
 To remove the container and start fresh, do podman rm ${TOOLBOX_NAME}.
+
+Commands are optional. The supported ones are:
+ list: List existing toolboxes
+ create: Just create the toolbox
+ enter: Enter inside a toolbox (if it does not exist, it is created)
+ run: Run command_to_run inside a toolbox (if it does not exist, it is created)
 
 Options:
   -h/--help: Shows this help message
@@ -197,15 +217,43 @@ TOOLBOX_NAME=special-debug-container
 TOOLBOX_SHELL=/bin/bash"
 }
 
+is_option() {
+    if [ "${1:0:1}" = "-" ]; then
+        return 1
+    fi
+    return 0
+}
+
 main() {
     # Execute setup first so we get proper variables
     setup
-    # If we are passed a help switch, show help and exit
+
+    # Deal with commands first. We want to support both "command mode"
+    # (compatible with Silverblue's toolbox) and the current "command-less"
+    # mode of operation. If wanting to use a command, that has to be the
+    # first argument. If no command is provided, we basically default to
+    # 'run', which is 'create, start and fire a shell inside the toolbox'.
+    #
+    # Note that, if a command is used, we set  "user" mode by default (i.e.,
+    # even if `-u` is not specified later). This is again for compatibility
+    # with https://github.com/containers/toolbox).
+    COMMAND=run
+    if [ ! -z $1 ] && is_option $1 ; then
+        case $1 in
+            create | list | enter | run )
+                MODE="user"
+                COMMAND=$1
+                shift
+                ;;
+        esac
+    fi
+
     ARGS=`getopt -o hrut:R:I: --long help,root,user,tag:,registry:,image: -n toolbox -- "$@"`
     eval set -- "$ARGS"
     while true; do
         case "$1" in
             -h|--help)
+                # If we are passed a help switch, show help and exit
                 show_help
                 exit 0
                 ;;
@@ -215,23 +263,10 @@ main() {
                 ;;
             -u|--user)
                 shift
-                USER_ID=`id -u`; USER_GID=`id -g`
-                USER_NAME=`id -un` ; USER_GNAME=`id -gn`
-                USER_HOME=$HOME
-                TOOLBOX_NAME="${TOOLBOX_NAME}-user"
-
-                # We want to keep the pid namespace of the running user.
-                # We, however, use root:root while creating, so that later we
-                # can modify the user's name, groups, etc, within the container.
-                CREATE_AS_USER="--pid host --userns=keep-id -v ${HOME}:${HOME} --user root:root --volume /run/user/${USER_ID}:/run/user/${USER_ID}:rslave --volume /run/media/:/run/media/:rslave --volume /tmp:/tmp:rslave"
-                for ENV in $USER_ENV ; do
-                    eval VAL="$""$ENV"
-                    [[ ! -z $VAL ]] && USER_ENV_STR="$USER_ENV_STR --env $ENV=$VAL"
-                done
-                EXEC_AS_USER="--user ${USER_ID}:${USER_GID} -w `pwd` $USER_ENV_STR"
+		MODE="user"
                 ;;
             -t|--tag)
-                TOOLBOX_NAME="${TOOLBOX_NAME}-$2"
+                TAG="$2"
                 shift 2
                 ;;
             -R|--registry)
@@ -258,12 +293,47 @@ main() {
         esac
     done
 
-    if [ -z "$*" ]; then
-	run ${TOOLBOX_SHELL}
-    else
-	run "$@"
+    if [ "$MODE" = "user" ]; then
+        USER_ID=`id -u`; USER_GID=`id -g`
+        USER_NAME=`id -un` ; USER_GNAME=`id -gn`
+        USER_HOME=$HOME
+        TOOLBOX_NAME="${TOOLBOX_NAME}-user"
+
+        # We want to keep the pid namespace of the running user.
+        # We, however, use root:root while creating, so that later we
+        # can modify the user's name, groups, etc, within the container.
+        CREATE_AS_USER="--pid host --userns=keep-id -v ${HOME}:${HOME} --user root:root --volume /run/user/${USER_ID}:/run/user/${USER_ID}:rslave --volume /run/media/:/run/media/:rslave --volume /tmp:/tmp:rslave"
+        for ENV in $USER_ENV ; do
+            eval VAL="$""$ENV"
+            [[ ! -z $VAL ]] && USER_ENV_STR="$USER_ENV_STR --env $ENV=$VAL"
+        done
+        EXEC_AS_USER="--user ${USER_ID}:${USER_GID} -w `pwd` $USER_ENV_STR"
     fi
-    cleanup
+
+    if [ ! -z $TAG ]; then
+        TOOLBOX_NAME="${TOOLBOX_NAME}-$TAG"
+    fi
+
+    case $COMMAND in
+        list)
+            list
+            ;;
+        create)
+            create
+            ;;
+        enter|run)
+            if [ -z "$*" ]; then
+                run ${TOOLBOX_SHELL}
+            else
+                run "$@"
+            fi
+            cleanup
+            ;;
+        *)
+            echo "unknown command: '$COMMAND'"
+            exit 1
+            ;;
+    esac
 }
 
 main "$@"


### PR DESCRIPTION
This pull request focuses on two things:

- trying to continue making the "toolbox experience" better, but exporting more environment variable add adding more bind-mounts inside the toolbox, resulting in the user feeling more comfortable when inside it and more programs and apps working from within there. E.g., apps that use sound now work from inside the toolbox too;
- adding support for a new UI, based on commands such as `create`, `enter`, and `run`. This makes our toolbox much more compatible (UI-wise) with the toolbox project that is used in Fedora Silverblue/CoreOS and EndlessOS. Of course, our existing ("command-less") UI is still there and is fully working and supported.

In fact, it has happened more than once already that users coming from Silverblue and wanting to try MicroOS Desktop were surprised/upset about not being able to use toolbox in the same way that they were over there. With these changes, transitioning between these OSes will be a lot easier for users.

We update the inline help and the README file accordingly too.