### PR TITLE
Improving using images of other distros as toolboxes

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -77,12 +77,12 @@ create() {
             container_runlabel
             return
         fi
-	# We want to do the user setup only when the container is created for the first time
-	[[ -n "${CREATE_AS_USER}" ]] && SETUP_USER=true
+        # We want to do the user setup only when the container is created for the first time
+        [[ -n "${CREATE_AS_USER}" ]] && SETUP_USER=true
     else
         echo "Container '$TOOLBOX_NAME' already exists. Trying to start..."
         echo "(To remove the container and start with a fresh toolbox, run: podman rm '$TOOLBOX_NAME')"
-	msg="start"
+        msg="start"
     fi
 
     local state
@@ -159,7 +159,7 @@ container_create() {
                  --privileged \
                  --security-opt label=disable ${CREATE_AS_USER} \
                  --volume /:/media/root:rslave \
-		 --volume /dev:/dev:rslave \
+                 --volume /dev:/dev:rslave \
                  "$TOOLBOX_IMAGE" sleep +Inf 2>&1; then
         echo "$0: failed to create container '$TOOLBOX_NAME'"
         exit 1
@@ -275,7 +275,7 @@ main() {
                 ;;
             -u|--user)
                 shift
-		MODE="user"
+                MODE="user"
                 ;;
             -c|--container)
                 if [ -z "$TAG" ]; then
@@ -328,7 +328,7 @@ main() {
     if [ "$MODE" = "user" ]; then
         USER_ID=$(id -u); USER_GID=$(id -g)
         USER_NAME=$(id -un) ; USER_GNAME=$(id -gn)
-	if [ -z "$CHANGE_NAME" ]; then
+        if [ -z "$CHANGE_NAME" ]; then
             TOOLBOX_NAME="${TOOLBOX_NAME}-user"
         fi
 

--- a/toolbox
+++ b/toolbox
@@ -100,16 +100,19 @@ create() {
         echo "this may take some time. But this will only happen now that the toolbox is being created)"
         local tmp_user_setup
         tmp_user_setup=$(mktemp "${HOME}/.${TOOLBOX_NAME}-user-setup-XXXXXX.sh")
+        tmp_user_setup_log="/dev/null"
+        # DEBUG: uncomment the following line to see logs of the script in /tmp
+        #tmp_user_setup_log="/tmp/$(basename -- ${tmp_user_setup}).log"
         cat <<EOF > "${tmp_user_setup}"
 #!/bin/bash
-groupadd -g ${USER_GID} ${USER_GNAME} &> /dev/null
-useradd -M -N -g ${USER_GNAME} -u ${USER_ID} ${USER_NAME} &> /dev/null
-getent group wheel >/dev/null || zypper install -y --no-recommends sudo system-group-wheel &> /dev/null
-echo "%wheel ALL = (root) NOPASSWD:ALL" > /etc/sudoers.d/wheel 2> /dev/null
-usermod -G wheel -a ${USER_NAME} &> /dev/null
+groupadd -g ${USER_GID} ${USER_GNAME}
+useradd -M -N -g ${USER_GNAME} -u ${USER_ID} ${USER_NAME}
+getent group wheel &>/dev/null || zypper install -y --no-recommends sudo system-group-wheel
+echo "%wheel ALL = (root) NOPASSWD:ALL" > /etc/sudoers.d/wheel
+usermod -G wheel -a ${USER_NAME}
 EOF
         ${SUDO} podman cp "${tmp_user_setup}" "${TOOLBOX_NAME}":"${tmp_user_setup}"
-        ${SUDO} podman exec --user root "${TOOLBOX_NAME}" bash "${tmp_user_setup}"
+        ${SUDO} podman exec --user root "${TOOLBOX_NAME}" bash "${tmp_user_setup}" &> "${tmp_user_setup_log}"
         ${SUDO} podman exec --user root "${TOOLBOX_NAME}" rm "${tmp_user_setup}"
     fi
 

--- a/toolbox
+++ b/toolbox
@@ -107,9 +107,10 @@ create() {
 #!/bin/bash
 groupadd -g ${USER_GID} ${USER_GNAME}
 useradd -M -N -g ${USER_GNAME} -u ${USER_ID} ${USER_NAME}
-getent group wheel &>/dev/null || zypper install -y --no-recommends sudo system-group-wheel
-echo "%wheel ALL = (root) NOPASSWD:ALL" > /etc/sudoers.d/wheel
-usermod -G wheel -a ${USER_NAME}
+if ! command -v sudo &> /dev/null ; then
+  zypper install -y --no-recommends sudo
+fi
+mkdir -p /etc/sudoers.d/ && echo "${USER_NAME} ALL = (root) NOPASSWD:ALL" > /etc/sudoers.d/${USER_NAME}
 EOF
         ${SUDO} podman cp "${tmp_user_setup}" "${TOOLBOX_NAME}":"${tmp_user_setup}"
         ${SUDO} podman exec --user root "${TOOLBOX_NAME}" bash "${tmp_user_setup}" &> "${tmp_user_setup_log}"

--- a/toolbox
+++ b/toolbox
@@ -160,6 +160,7 @@ container_create() {
                  --security-opt label=disable ${CREATE_AS_USER} \
                  --volume /:/media/root:rslave \
                  --volume /dev:/dev:rslave \
+                 --volume /etc/machine-id:/etc/machine-id:ro \
                  "$TOOLBOX_IMAGE" sleep +Inf 2>&1; then
         echo "$0: failed to create container '$TOOLBOX_NAME'"
         exit 1
@@ -339,7 +340,7 @@ main() {
         test -d "${HOME}" && VOLUMES="$VOLUMES --volume ${HOME}:${HOME}"
         test -d "/run/user/${USER_ID}" && VOLUMES="$VOLUMES --volume /run/user/${USER_ID}:/run/user/${USER_ID}:rslave"
         test -d /run/media && VOLUMES="$VOLUMES --volume /run/media/:/run/media/:rslave"
-        CREATE_AS_USER="--pid host --userns=keep-id --user root:root $VOLUMES"
+        CREATE_AS_USER="--pid host --ipc host --userns=keep-id --user root:root $VOLUMES"
         for ENV in $USER_ENV ; do
             eval VAL="$""$ENV"
             [[ -n "$VAL" ]] && USER_ENV_STR="$USER_ENV_STR --env $ENV=$VAL"


### PR DESCRIPTION
Hi! So, the main point of this series is to simplify the setup of sudo, inside an "user toolbox" so that it depends less from installing packages with zypper. In fact, that would mean that other distro images can be used as toolboxes. We still use zypper for one thing (i.e., installing `sudo`, if the image does not have it), which ideally we also want to remove, but let's do things in step.

While there, do some more compatibility (with other implementations), some more "host forwarding" and some more formatting fixes.