### PR TITLE
Fix custom container name and improve error reporting

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -148,6 +148,17 @@ image_runlabel() {
 }
 
 image_pull() {
+    if [ -z ${SUDO} ]; then
+        if [ ! `grep $USER /etc/subuid` ] || [ ! `grep $USER /etc/subgid` ]; then
+            echo "$0: ERROR: rootless mode wanted but no subuid and/or subgid for user '$USER'"
+            echo " Toolbox will only work for this user if rootless podman is configured properly."
+            echo " consider doing something like this:"
+            echo "    sudo usermod --add-subuids 100000-165535 --add-subgids 100000-165535 $USER"
+            echo " and then restart."
+            echo " Or use '-r', for using a rootfull container."
+            exit 1
+        fi
+    fi
     ${SUDO} podman pull "$TOOLBOX_IMAGE"
 }
 

--- a/toolbox
+++ b/toolbox
@@ -283,7 +283,7 @@ main() {
                 MODE="user"
                 ;;
             -c|--container)
-                if [ -z "$TAG" ]; then
+                if [ -n "$TAG" ]; then
                     echo "ERROR: Don't use both -c and -t!"
                     show_help
                     exit 1


### PR DESCRIPTION
These patches:

- fix an error when a custom container name is provided with '-c'
- bail early, with an hopefully meaningful and actionable error message, if the user asks for a rootless toolbox, but subuid/gid are not there