### PR TITLE
Fix problem with creating containers with -c flag

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -283,7 +283,7 @@ main() {
                 MODE="user"
                 ;;
             -c|--container)
-                if [ -z "$TAG" ]; then
+                if [ -n "$TAG" ]; then
                     echo "ERROR: Don't use both -c and -t!"
                     show_help
                     exit 1


### PR DESCRIPTION

Addresses: https://github.com/kubic-project/microos-toolbox/issues/19

When trying to create a toolbox container with `-c` option
and without `-t`, it complains that `-c` and `-t` can't be
given at the same time.