### PR TITLE
Avoid copying the user setup script with 'podman cp'

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -110,7 +110,6 @@ if ! command -v sudo &> /dev/null ; then
 fi
 mkdir -p /etc/sudoers.d/ && echo "${USER_NAME} ALL = (root) NOPASSWD:ALL" > /etc/sudoers.d/${USER_NAME}
 EOF
-        ${SUDO} podman cp "${tmp_user_setup}" "${TOOLBOX_NAME}":"${tmp_user_setup}"
         ${SUDO} podman exec --user root "${TOOLBOX_NAME}" bash "${tmp_user_setup}" &> "${tmp_user_setup_log}"
         ${SUDO} podman exec --user root "${TOOLBOX_NAME}" rm "${tmp_user_setup}"
     fi
@@ -127,6 +126,7 @@ run() {
 
 cleanup() {
     ${SUDO} podman stop "$TOOLBOX_NAME" &>/dev/null
+    ${SUDO} rm -f $tmp_user_setup
 }
 
 container_exists() {


### PR DESCRIPTION
We needed to copy the setup script (for user toolboxes), when they were
generated in /tmp on the host. But they're currently generated directly
in $HOME, and since we bind mount $HOME... well, it's just already
there (and one can even argue that it's a bug copying it!).

So, not copying is the right thing do to and, nicely enough, it also
workarounds what apparently is a podman 3 issue with 'podman cp',
basically fixing issue #25 too.

While there, add cleanup logic for the same user setup script. In fact,
if everything goes fine, the script is removed by the toolbox itself
(after executing it). But if there's an error and we bail, it may stick
around, cluttering the home directory.

Signed-off-by: Dario Faggioli <dfaggioli@suse.com>