### PR TITLE
Fix 'toolbox list' returning an error code even if working

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -162,6 +162,7 @@ image_pull() {
 
 list() {
     ${SUDO} podman ps --all
+    exit $?
 }
 
 container_create() {
@@ -335,6 +336,12 @@ main() {
         esac
     done
 
+    # Handle list before setting up the cleanup trap, as we won't need
+    # to try to stop the container, in that case
+    if [ "$COMMAND" == "list" ]; then
+        list
+    fi
+
     # Don't call trap before, else we will cleanup stuff
     # where nothing is to cleanup and report wrong error
     trap cleanup EXIT
@@ -370,9 +377,6 @@ main() {
     fi
 
     case $COMMAND in
-        list)
-            list
-            ;;
         create)
             create
             ;;


### PR DESCRIPTION
The cleanup handler always tries to stop the container. If we're only
listing existing containers, there's nothing to stop and the 'podman
stop' command gives an error, which is then used as the exit status.

This means that when doing 'toolbox list', it always looks like it's
failing even when it actually worked.

Fix that by handling the case of only listing the containers (i.e.,
the list command) before installing the cleanup handler. This should
fix issue #23.

Signed-off-by: Dario Faggioli <dfaggioli@suse.com>