### PR TITLE
Fix `toolbox list`, localtime and mount /sys

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -174,7 +174,9 @@ container_create() {
                  --security-opt label=disable ${CREATE_AS_USER} \
                  --volume /:/media/root:rslave \
                  --volume /dev:/dev:rslave \
+                 --volume /sys:/sys:rslave \
                  --volume /etc/machine-id:/etc/machine-id:ro \
+                 --volume /etc/localtime:/etc/localtime:ro \
                  "$TOOLBOX_IMAGE" sleep +Inf 2>&1; then
         echo "$0: failed to create container '$TOOLBOX_NAME'"
         exit 1

--- a/toolbox
+++ b/toolbox
@@ -162,6 +162,7 @@ image_pull() {
 
 list() {
     ${SUDO} podman ps --all
+    exit $?
 }
 
 container_create() {
@@ -335,6 +336,12 @@ main() {
         esac
     done
 
+    # Handle list before setting up the cleanup trap, as we won't need
+    # to try to stop the container, in that case
+    if [ "$COMMAND" == "list" ]; then
+        list
+    fi
+
     # Don't call trap before, else we will cleanup stuff
     # where nothing is to cleanup and report wrong error
     trap cleanup EXIT
@@ -370,9 +377,6 @@ main() {
     fi
 
     case $COMMAND in
-        list)
-            list
-            ;;
         create)
             create
             ;;


### PR DESCRIPTION
Fix issue #23 with `toolbox list`. Also fix localtime inside the toolbox and bind mount /sys as well so, for example, we can do tracing from inside the toolbox.