### PR TITLE
Properly share namespaces in non-user toolboxes

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -170,6 +170,8 @@ container_create() {
                  --hostname "$TOOLBOX_NAME" \
                  --name "$TOOLBOX_NAME" \
                  --network host \
+                 --pid host \
+                 --ipc host \
                  --privileged \
                  --security-opt label=disable ${CREATE_AS_USER} \
                  --volume /:/media/root:rslave \
@@ -366,7 +368,7 @@ main() {
         test -d "${HOME}" && VOLUMES="$VOLUMES --volume ${HOME}:${HOME}"
         test -d "/run/user/${USER_ID}" && VOLUMES="$VOLUMES --volume /run/user/${USER_ID}:/run/user/${USER_ID}:rslave"
         test -d /run/media && VOLUMES="$VOLUMES --volume /run/media/:/run/media/:rslave"
-        CREATE_AS_USER="--pid host --ipc host --userns=keep-id --user root:root $VOLUMES"
+        CREATE_AS_USER="--userns=keep-id --user root:root $VOLUMES"
         for ENV in $USER_ENV ; do
             eval VAL="$""$ENV"
             [[ -n "$VAL" ]] && USER_ENV_ARR+=(--env "$ENV=$VAL")


### PR DESCRIPTION
When starting a "non-user" toolbox (i.e., starting without `-u`,
whether it's rootful or not), we currently do no share the PID and
IPC namespaces.

And that is bad, because non-user toolboxes are meant for debugging
and troubleshooting. And being able, say, to strace or attach GDB to
an host process is a super useful debugging feature.

And we need to share the host namespace, in order for that to be
possible.

Signed-off-by: Dario Faggioli <dfaggioli@suse.com>