### PR TITLE
Introduce -n/--nostop switch so mutiple sessions can be run

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ You can also install and run GUI applications in your `toolbox` container. The r
 The following options are available in `toolbox`:
 * `-h` or `--help`: Shows the help message
 * `-u` or `--user`: Run as the current user inside the container
+* `-n` or `--nostop`: Do not stop container on exit, allowing multiple sessions to the same toolbox
 * `-R` or `--reg` `<registry>`: Explicitly specify the registry to use
 * `-I` or `--img` `<image>`: Explicitly specify the image to pull
 * `-i` or `--image` `<image>`: Full URI of the image to pull (alternative to `-R` & `-I`)

--- a/toolbox
+++ b/toolbox
@@ -130,7 +130,10 @@ run() {
 }
 
 cleanup() {
-    ${SUDO} $CLI stop "$TOOLBOX_NAME" &>/dev/null
+    if [ -z "$NO_STOP" ]; then
+	${SUDO} $CLI stop "$TOOLBOX_NAME" &>/dev/null
+    fi
+
     ${SUDO} rm -f $tmp_user_setup
 }
 
@@ -215,7 +218,7 @@ container_exec() {
 }
 
 show_help() {
-    echo "USAGE: toolbox [[-h/--help] | [command] [-r/--root] [-u/--user]
+    echo "USAGE: toolbox [[-h/--help] | [command] [-r/--root] [-u/--user] [-n/--nostop]
         [[-R/--reg <registry>] [-I/--img <image>]|[-i/--image <image_URI>]]
         [[-t/--tag <tag>]|[-c/--container <name>]] [command_to_run]]
 toolbox is a small script that launches a container to let you bring in your favorite debugging or admin tools.
@@ -232,6 +235,8 @@ Options:
   -h/--help: Shows this help message
   -u/--user: Run as the current user inside the container
   -r/--root: Runs $CLI via sudo as root
+  -n/--nostop: Does not stop the container on exit, allowing multiple
+               sessions to use the same toolbox at once
   -t/--tag <tag>: Add <tag> to the toolbox name
   -c/--container <name>: Set the name of the toolbox to be equal to <name>
                          (use this alternatively to -t)
@@ -284,7 +289,7 @@ main() {
         esac
     fi
 
-    ARGS=$(getopt -o hrut:R:I:c:i: --long help,root,user,tag:,reg:,img:,container:,image: -n toolbox -- "$@")
+    ARGS=$(getopt -o hrunt:R:I:c:i: --long help,root,user,nostop,tag:,reg:,img:,container:,image: -n toolbox -- "$@")
     eval set -- "$ARGS"
     while true; do
         case "$1" in
@@ -300,6 +305,10 @@ main() {
             -u|--user)
                 shift
                 MODE="user"
+                ;;
+            -n|--nostop)
+                NO_STOP="true"
+                shift
                 ;;
             -c|--container)
                 if [ -n "$TAG" ]; then


### PR DESCRIPTION
**Background**

I'm using MicroOS Desktop as my daily driver and so am running toolbox pretty much as my main 'work shell' for all my day to day ops, with a custom image based on the official toolbox image with just a few extras I need (osc, zsh, etc)

My daily workflow has been as follows

Start at least 2 copies of `gnome-terminal`
Run `toolbox -u` in each gnome-terminal
`sudo zsh` in at least one of those toolboxes

The `sudo zsh` (inside `toolbox -u`) shell ends up being my `osc` environment for staging/Factory release management, using different OBS auth than my regular `toolbox -u` shell

The problem is, if I exit ANY of my `toolbox -u` sessions, they all die, because the container gets stopped on exit as part of the cleanup trap.

This is really annoying, and so, I wanted a fix

**TL;DR / The Fix**
This PR introduces a `-n / --nostop` switch for `toolbox` which prevents the container from getting cleaned up on exit.

The tmp_user_setup script cleanup still happens, but the container remains running

This means `toolbox -u -n` can be called repeatedly, at the same time, and all of those sessions will remain valid and work even as they are closed down.

Personally, I'd like this behaviour as the default, but figured I'd start with this change and see how it's accepted.

This has been tested..it's the code I'm actually running myself for my daily work with toolbox.