### PR TITLE
Make toolbox k8s (rke2) aware

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -207,10 +207,12 @@ container_create() {
        SUSECONNECT_FILES="$SUSECONNECT_FILES --volume /etc/zypp/credentials.d/SCCcredentials:/etc/zypp/credentials.d/SCCcredentials"
     fi
     local RKE_ARGS=""
-    if is_rke2_server; then
-      RKE_ARGS="$RKE_ARGS --volume /etc/rancher/rke2/rke2.yaml:/etc/rancher/rke2/rke2.yaml:ro"
-      RKE_ARGS="$RKE_ARGS --env KUBECONFIG=/etc/rancher/rke2/rke2.yaml"
-      RKE_ARGS="$RKE_ARGS --volume /var/lib/rancher/rke2/bin/kubectl:/usr/local/bin/kubectl:ro"
+    if [ -s /var/lib/rancher/rke2/bin/kubectl ]; then
+        RKE_ARGS="$RKE_ARGS --volume /var/lib/rancher/rke2/bin/kubectl:/usr/local/bin/kubectl:ro"
+    fi
+    if [ -s /etc/rancher/rke2/rke2.yaml ]; then
+        RKE_ARGS="$RKE_ARGS --volume /etc/rancher/rke2/rke2.yaml:/etc/rancher/rke2/rke2.yaml:ro"
+        RKE_ARGS="$RKE_ARGS --env KUBECONFIG=/etc/rancher/rke2/rke2.yaml"
     fi
     if ! ${SUDO} $CLI create \
                  $RUNTIME \
@@ -315,19 +317,6 @@ is_option() {
     if [ "${1:0:1}" = "-" ]; then
         return 1
     fi
-    return 0
-}
-
-is_rke2_server() {
-    files=("/var/lib/rancher/rke2/bin/kubectl" "/etc/rancher/rke2/rke2.yaml")
-
-    for i in "${files[@]}"
-    do
-      if [ ! -s $i ]; then
-        return 1
-      fi
-    done
-
     return 0
 }
 

--- a/toolbox
+++ b/toolbox
@@ -319,16 +319,16 @@ is_option() {
 }
 
 is_rke2_server() {
-  files=("/var/lib/rancher/rke2/bin/kubectl" "/etc/rancher/rke2/rke2.yaml")
+    files=("/var/lib/rancher/rke2/bin/kubectl" "/etc/rancher/rke2/rke2.yaml")
 
-  for i in "${files[@]}";
-  do
-    if ! test -f $i; then
-      return 1
-    fi
-  done
+    for i in "${files[@]}"
+    do
+      if [ ! -s $i ]; then
+        return 1
+      fi
+    done
 
-  return 0
+    return 0
 }
 
 main() {

--- a/toolbox
+++ b/toolbox
@@ -206,6 +206,12 @@ container_create() {
     if [ -s /etc/zypp/credentials.d/SCCcredentials ]; then
        SUSECONNECT_FILES="$SUSECONNECT_FILES --volume /etc/zypp/credentials.d/SCCcredentials:/etc/zypp/credentials.d/SCCcredentials"
     fi
+    local RKE_ARGS=""
+    if is_rke2_server; then
+      RKE_ARGS="$RKE_ARGS --volume /etc/rancher/rke2/rke2.yaml:/etc/rancher/rke2/rke2.yaml:ro"
+      RKE_ARGS="$RKE_ARGS --env KUBECONFIG=/etc/rancher/rke2/rke2.yaml"
+      RKE_ARGS="$RKE_ARGS --volume /var/lib/rancher/rke2/bin/kubectl:/usr/local/bin/kubectl:ro"
+    fi
     if ! ${SUDO} $CLI create \
                  $RUNTIME \
                  --hostname "$TOOLBOX_NAME" \
@@ -217,6 +223,7 @@ container_create() {
                  --volume /etc/localtime:/etc/localtime:ro \
                  ${SUSECONNECT_FILES} \
                  ${PODMAN_ARGS[@]} \
+                 ${RKE_ARGS} \
                  "$TOOLBOX_IMAGE" sleep +Inf > /dev/null; then
         echo "$0: failed to create container '$TOOLBOX_NAME'"
         exit 1
@@ -309,6 +316,19 @@ is_option() {
         return 1
     fi
     return 0
+}
+
+is_rke2_server() {
+  files=("/var/lib/rancher/rke2/bin/kubectl" "/etc/rancher/rke2/rke2.yaml")
+
+  for i in "${files[@]}";
+  do
+    if ! test -f $i; then
+      return 1
+    fi
+  done
+
+  return 0
 }
 
 main() {


### PR DESCRIPTION
If toolbox is running on an RKE2 server node, make related troubleshooting and debugging possible from within.

EDIT: I'll squash the commits into one once there's an approval. Have avoided doing force push so that there's a clear way to compare changes between iterations.
